### PR TITLE
Add integration documentation for Geany

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -227,5 +227,5 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) t [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
 
 ```
-if docker run --rm -i hadolint/hadolint < "%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -219,3 +219,13 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 [vscode-hadolint-gif]: https://i.gyazo.com/a701460ccdda13a1a449b2c3e8da40bc.gif
 [vs code]: https://code.visualstudio.com/
 [exiasr]: https://github.com/ExiaSR
+
+### Geany
+
+> Geany is a powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow. It runs on Linux, Windows and MacOS is translated into over 40 languages, and has built-in support for more than 50 programming languages.
+
+The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) t [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
+
+```
+if docker run --rm -i hadolint/hadolint < "%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+```


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
I added a section to the integration documentation that describes how to include hadolint as a linter into Geany's build system.

### How I did it
I copied and pasted the relevant code from configuration.  Specifically, the code kicks off a Docker container with hadolint/hadolint then massages the output with sed into a format that Geany interprets as an error location.  If the output includes a string (in this case, ':WARNING:') then the build (lint) is marked as having failed.

Geany's build system runs the command via `/bin/sh -c ' (stuff) '` with quotes escaped and the following replacements:

%d directory to the file being edited / run
%f filename (basename -- no directory)

Screenshot:
![Screenshot_2019-11-06_15-44-42](https://user-images.githubusercontent.com/45051395/68337050-af620400-00ad-11ea-963c-32fcc21dca51.png)

### How to verify it
Open a Dockerfile, include the code in Geany's build actions, and run it.